### PR TITLE
Fix layout width and button label in workspace/user views

### DIFF
--- a/apps/users/templates/account/connected_accounts.html
+++ b/apps/users/templates/account/connected_accounts.html
@@ -7,7 +7,7 @@
 {% block app_content_content %}
 <div id="page-content" hx-target="#page-content">
   {% partialdef page-content inline %}
-  <section class="app-card">
+  <section class="app-card mt-form-page">
     {% include 'accounts/includes/social/social_accounts.html' %}
   </section>
   {% endpartialdef page-content %}

--- a/apps/users/templates/socialaccount/connections.html
+++ b/apps/users/templates/socialaccount/connections.html
@@ -10,7 +10,7 @@
   {% endwith %}
 {% endblock %}
 {% block app_content_content %}
-  <div class="app-card">
+  <div class="app-card mt-form-page">
     <p class="mt-text-right"><a href="{% url 'users:user_profile' %}">{% translate '← Return to Profile' %}</a></p>
     <h1 class="mt-title">{% translate "Connected Accounts" %}</h1>
     {% if form.accounts %}
@@ -48,7 +48,7 @@
       {% if provider.id == "github" %}
         <form method="post" class="mt-2" action="{% provider_login_url provider process='connect' %}">
           {% csrf_token %}
-          <button class="btn btn-primary btn-outline flex justify-center my-2 w-1/4" type="submit">
+          <button class="btn btn-primary btn-outline flex justify-center my-2 whitespace-nowrap" type="submit">
             <img class="socialicon mr-2" src="{% static provider.logo_path %}" alt="GitHub Logo">
             {% translate "Connect Github Account" %}
           </button>

--- a/apps/workspaces/templates/workspaces/includes/invite_modal.html
+++ b/apps/workspaces/templates/workspaces/includes/invite_modal.html
@@ -13,7 +13,7 @@
       </div>
       <div class="modal-action">
         <label for="invite-modal-toggle" class="btn">{% translate "Cancel" %}</label>
-        <input class="mt-button-secondary" type="submit" value="{% translate 'Send Invitation' %}">
+        <input class="mt-button-secondary" type="submit" value="{% translate 'Send Invite' %}">
       </div>
     </form>
   </div>

--- a/apps/workspaces/templates/workspaces/includes/workspace_invitations.html
+++ b/apps/workspaces/templates/workspaces/includes/workspace_invitations.html
@@ -9,7 +9,7 @@
       {% render_form_fields invitation_form %}
       {{ invitation_form.non_field_errors }}
       <div class="mt-inline-buttons mt-2">
-        <input class="mt-button-secondary" type="submit" value="{% translate 'Send Invitation' %}">
+        <input class="mt-button-secondary" type="submit" value="{% translate 'Send Invite' %}">
       </div>
     </form>
   </section>

--- a/apps/workspaces/templates/workspaces/list_workspaces.html
+++ b/apps/workspaces/templates/workspaces/list_workspaces.html
@@ -3,7 +3,7 @@
 {% block app_content_content %}
 <div id="page-content" hx-target="#page-content">
   {% partialdef page-content inline %}
-  <div class="app-card">
+  <div class="app-card mt-form-page">
     <div class="flex justify-between items-center mb-4">
       <h3 class="mt-subtitle mb-0">{% translate "My Workspaces" %}</h3>
       <a href="{% url 'workspaces:create_workspace' %}" class="btn btn-primary btn-sm">

--- a/apps/workspaces/templates/workspaces/manage_workspace_members.html
+++ b/apps/workspaces/templates/workspaces/manage_workspace_members.html
@@ -15,7 +15,7 @@
 {% block app_content_content %}
 <div id="page-content" hx-target="#page-content">
   {% partialdef page-content inline %}
-  <section class="app-card">
+  <section class="app-card mt-form-page">
     <div class="flex justify-between items-center mb-4">
       <h3 class="mt-subtitle mb-0">{% translate "Workspace Members" %}</h3>
       {% if request.workspace_membership.is_admin %}
@@ -49,7 +49,7 @@
       </table>
     </div>
   </section>
-  <div id="pending-invitations">
+  <div id="pending-invitations" class="mt-form-page">
     {% include 'workspaces/includes/pending_invitations.html' %}
   </div>
   {% if request.workspace_membership.is_admin %}

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -4166,7 +4166,7 @@ msgstr ""
 
 #: apps/workspaces/templates/workspaces/includes/invite_modal.html:16
 #: apps/workspaces/templates/workspaces/includes/workspace_invitations.html:12
-msgid "Send Invitation"
+msgid "Send Invite"
 msgstr ""
 
 #: apps/workspaces/templates/workspaces/includes/pending_invitations.html:4


### PR DESCRIPTION
- Add mt-form-page to My Workspaces, Members, Connected Accounts, and /accounts/3rdparty/ views so they use the same centered layout as other views in those apps
- Fix "Connect Github Account" button wrapping by replacing w-1/4 with whitespace-nowrap
- Rename "Send Invitation" button label to "Send Invite" in templates and locale catalog

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox/pr/matorral-project/matorral/156?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->