### PR TITLE
fix: upgrade PyJWT to 2.12.1 to address crit header validation vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "channels",
     "channels_redis",
     "django-allauth[socialaccount]>=65.13.0",
+    "PyJWT>=2.12.0",
     "django-attachments",
     "django-anymail[mailgun]",
     "django-auditlog>=3.4.1",

--- a/uv.lock
+++ b/uv.lock
@@ -956,6 +956,7 @@ dependencies = [
     { name = "django-watchfiles" },
     { name = "factory-boy" },
     { name = "psycopg2-binary" },
+    { name = "pyjwt" },
     { name = "python-dateutil" },
     { name = "redis" },
     { name = "sentry-sdk", extra = ["django"] },
@@ -1004,6 +1005,7 @@ requires-dist = [
     { name = "django-watchfiles" },
     { name = "factory-boy", specifier = ">=3.3.3" },
     { name = "psycopg2-binary" },
+    { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "python-dateutil" },
     { name = "redis" },
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.33.2" },
@@ -1180,11 +1182,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
this fixes https://github.com/matorral-project/matorral/security/dependabot/77